### PR TITLE
Configure initial Swift website setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .swiftpm/
 *.xcodeproj
 xcuserdata/
+deploy/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# Agent Instructions
+
+This repository contains a personal static website built with Swift and Saga.
+
+## Project Context
+
+- Use Saga as the static site generator.
+- The Swift executable target lives in `Sources/Rychillie`.
+- Conductor helper scripts live in `Sources/Scripts` and should not be moved into `Sources/Rychillie`.
+- Content lives in `content/`.
+- Generated output goes to `deploy/` and should not be edited or committed.
+
+## Development Rules
+
+- Keep repository documentation and agent-facing instructions in English.
+- Prefer editing source templates, content files, and styles over generated files.
+- Use `origin/main` as the comparison base for diffs and pull requests in Conductor workspaces.
+- Do not rename the current branch unless the user explicitly asks.
+- Keep changes focused on the requested website behavior, content, or configuration.
+
+## Validation
+
+- Run `saga build` after meaningful changes to Swift templates, Saga configuration, styles, or content.
+- Use `saga dev --port "$CONDUCTOR_PORT"` for local preview inside Conductor when needed.
+- If the Saga CLI is missing, install it with:
+
+```sh
+brew install loopwerk/tap/saga
+```

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,105 @@
+{
+  "originHash" : "3ba0db8bd0c34ae4fb8bcf5527e46ce90e86a90da2548b346372d41a4e8a8142",
+  "pins" : [
+    {
+      "identity" : "jxkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jectivex/JXKit",
+      "state" : {
+        "revision" : "a4c1872d36036fe4ade4b1cadb268603e89e25f0",
+        "version" : "3.6.0"
+      }
+    },
+    {
+      "identity" : "moon",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/loopwerk/Moon",
+      "state" : {
+        "revision" : "439d48259e278863203f5a6f67bb45c84ffbd360",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "parsley",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/loopwerk/Parsley",
+      "state" : {
+        "revision" : "1384f65054372000ded7dbf1f4b4e27c8fac2198",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "saga",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/loopwerk/Saga",
+      "state" : {
+        "revision" : "5f78c45913cda0737525a913d3a2b80dbdc1f9db",
+        "version" : "3.4.1"
+      }
+    },
+    {
+      "identity" : "sagaparsleymarkdownreader",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/loopwerk/SagaParsleyMarkdownReader",
+      "state" : {
+        "revision" : "b44f4d89688eb4c2266d149b897e547598df0f97",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "sagapathkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/loopwerk/SagaPathKit",
+      "state" : {
+        "revision" : "98e591dc42163f674f238c30b14c14e23f30e5a1",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "sagaswimrenderer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/loopwerk/SagaSwimRenderer",
+      "state" : {
+        "revision" : "05e68daf645d68cbb00658890a31083e9b1edb90",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-cmark",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-cmark.git",
+      "state" : {
+        "revision" : "924936d0427cb25a61169739a7660230bffa6ea6",
+        "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    },
+    {
+      "identity" : "swim",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/robb/Swim",
+      "state" : {
+        "revision" : "a0943e6f3cb5751ee7b69ed43a33613ea67d0c6a",
+        "version" : "0.4.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,48 @@
+# Rychillie.net
+
+Personal static website built with [Saga](https://getsaga.dev), a Swift static site generator.
+
+## Requirements
+
+- Swift 6.0 or newer
+- macOS 14 or newer
+- Saga CLI
+
+Install the Saga CLI with Homebrew:
+
+```sh
+brew install loopwerk/tap/saga
+```
+
+## Development
+
+Start the Saga development server:
+
+```sh
+saga dev --port 3000
+```
+
+Build the static site:
+
+```sh
+saga build
+```
+
+Saga reads content from `content/` and writes the generated site to `deploy/`.
+
+## Project Layout
+
+- `Package.swift`: Swift package definition and Saga dependencies.
+- `Sources/Rychillie/`: Swift entry point and HTML templates for the site.
+- `Sources/Scripts/`: Repository scripts used by Conductor.
+- `content/`: Markdown pages, articles, and static assets.
+- `deploy/`: Generated static site output. This directory is not committed.
+
+## Conductor
+
+This repository includes shared Conductor scripts in `conductor.json`.
+
+- Setup verifies that Swift and the Saga CLI are available.
+- Run starts `saga dev` on `CONDUCTOR_PORT`, falling back to port `3000` outside Conductor.
+
+Conductor scripts are configured to run concurrently because each workspace receives its own port range.

--- a/Sources/Scripts/conductor-run.sh
+++ b/Sources/Scripts/conductor-run.sh
@@ -1,0 +1,9 @@
+#!/bin/zsh
+
+set -e
+set -u
+set -o pipefail
+
+PORT="${CONDUCTOR_PORT:-3000}"
+
+exec saga dev --port "$PORT"

--- a/Sources/Scripts/conductor-setup.sh
+++ b/Sources/Scripts/conductor-setup.sh
@@ -1,0 +1,22 @@
+#!/bin/zsh
+
+set -e
+set -u
+set -o pipefail
+
+if ! command -v swift >/dev/null 2>&1; then
+  echo "Swift was not found in PATH."
+  exit 1
+fi
+
+if ! command -v saga >/dev/null 2>&1; then
+  echo "Saga CLI was not found in PATH."
+  echo "Install it with: brew install loopwerk/tap/saga"
+  exit 1
+fi
+
+SWIFT_VERSION="$(swift --version 2>&1 | sed -n '1p')"
+
+echo "Swift: $SWIFT_VERSION"
+echo "Saga CLI: $(command -v saga)"
+echo "Conductor setup complete."

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,7 @@
+{
+  "scripts": {
+    "setup": "zsh Sources/Scripts/conductor-setup.sh",
+    "run": "zsh Sources/Scripts/conductor-run.sh"
+  },
+  "runScriptMode": "concurrent"
+}


### PR DESCRIPTION
Configures initial repository docs for the Swift/Saga static website, including README and AGENTS guidance.

Adds shared Conductor setup and run scripts under `Sources/Scripts` and wires them through `conductor.json` with concurrent run mode.

Locks SwiftPM dependency resolution in `Package.resolved` and ignores generated `deploy/` output.

Validated with Conductor JSON parsing, the setup script, `saga build`, the run script on port 3007, and an HTTP 200 check.
