### PR TITLE
Configure SwiftLint for Rychillie.net

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Lint and Build
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install build tools
+        run: brew install loopwerk/tap/saga imagemagick swiftlint
+
+      - name: Lint Swift
+        run: swiftlint lint --quiet
+
+      - name: Build site
+        run: saga build
+
+      - name: Verify build output
+        run: test -f deploy/index.html

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -22,7 +22,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install build tools
-        run: brew install loopwerk/tap/saga imagemagick
+        run: brew install loopwerk/tap/saga imagemagick swiftlint
+
+      - name: Lint Swift
+        run: swiftlint lint --quiet
 
       - name: Build site
         run: saga build

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,34 @@
+included:
+  - Package.swift
+  - Sources/Rychillie
+
+excluded:
+  - .build
+  - .swiftpm
+  - deploy
+  - content/static/styles.css
+  - content/static/home/optimized
+  - Sources/Scripts
+
+strict: true
+
+disabled_rules:
+  - trailing_comma
+
+line_length:
+  warning: 340
+  error: 380
+  ignores_comments: true
+  ignores_urls: true
+  ignores_interpolated_strings: true
+  ignores_multiline_strings: true
+
+function_body_length:
+  warning: 100
+  error: 150
+
+file_length:
+  warning: 500
+  error: 1000
+
+reporter: xcode

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ The site is generated from localized Markdown content in `content/`, rendered by
 - Swift 6.0 or newer
 - macOS 14 or newer
 - Saga CLI
+- ImageMagick
+- SwiftLint
 
-Install the Saga CLI with Homebrew:
+Install the build tools with Homebrew:
 
 ```sh
-brew install loopwerk/tap/saga
+brew install loopwerk/tap/saga imagemagick swiftlint
 ```
 
 ## Development
@@ -28,6 +30,12 @@ Build the static site:
 
 ```sh
 saga build
+```
+
+Run SwiftLint:
+
+```sh
+swiftlint lint --quiet
 ```
 
 Saga reads localized content from `content/` and writes the generated site to `deploy/`.
@@ -84,16 +92,17 @@ The workflow:
 
 1. Runs on `macos-latest`.
 2. Checks out the repository.
-3. Installs the Saga CLI with Homebrew.
-4. Runs `saga build`.
-5. Verifies `deploy/index.html`.
-6. Deploys `deploy/` to Cloudflare Pages with `cloudflare/wrangler-action@v3`.
+3. Installs the Saga CLI, ImageMagick, and SwiftLint with Homebrew.
+4. Runs `swiftlint lint --quiet`.
+5. Runs `saga build`.
+6. Verifies `deploy/index.html`.
+7. Deploys `deploy/` to Cloudflare Pages with `cloudflare/wrangler-action@v3`.
 
 ## Conductor
 
 This repository includes shared Conductor scripts in `conductor.json`.
 
-- Setup verifies that Swift and the Saga CLI are available.
+- Setup verifies that Swift, the Saga CLI, ImageMagick, and SwiftLint are available.
 - Run starts `saga dev` on `CONDUCTOR_PORT`, falling back to port `3000` outside Conductor.
 
 Conductor scripts are configured to run concurrently because each workspace receives its own port range.

--- a/Sources/Scripts/conductor-setup.sh
+++ b/Sources/Scripts/conductor-setup.sh
@@ -21,9 +21,16 @@ if ! command -v magick >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! command -v swiftlint >/dev/null 2>&1; then
+  echo "SwiftLint was not found in PATH."
+  echo "Install it with: brew install swiftlint"
+  exit 1
+fi
+
 SWIFT_VERSION="$(swift --version 2>&1 | sed -n '1p')"
 
 echo "Swift: $SWIFT_VERSION"
 echo "Saga CLI: $(command -v saga)"
 echo "ImageMagick: $(command -v magick)"
+echo "SwiftLint: $(command -v swiftlint)"
 echo "Conductor setup complete."


### PR DESCRIPTION
Adds SwiftLint configuration for the Swift/Saga website with pragmatic thresholds that pass the current codebase while excluding generated/build output.

Updates local setup and README docs so SwiftLint is installed and runnable alongside Saga and ImageMagick.

Adds pull request CI and runs SwiftLint in the Cloudflare Pages deploy workflow before the Saga build.

Validation: `swiftlint lint --quiet`, `saga build`, `test -f deploy/index.html`, `git diff --check`, `zsh -n Sources/Scripts/conductor-setup.sh`, and YAML parsing for workflows/.swiftlint.yml.