### PR TITLE
Add AI-friendly Markdown access

### DIFF
--- a/Sources/Rychillie/Core/LLMS.swift
+++ b/Sources/Rychillie/Core/LLMS.swift
@@ -1,0 +1,192 @@
+import Foundation
+import Saga
+
+enum LLMS {
+  static func renderIndex(context: PageRenderingContext) throws -> String {
+    let notes = sortedNotes(from: context.allItems)
+    let englishNotes = notes.filter { Site.currentLocale($0.locale) == Site.defaultLocale }
+    let portugueseNotes = notes.filter { Site.currentLocale($0.locale) == Site.portugueseLocale }
+
+    return [
+      "# \(Site.name)",
+      "",
+      "> \(Site.copy(for: Site.defaultLocale).intro)",
+      "",
+      "This file points AI agents to canonical profile context and clean Markdown versions of the public notes on this website.",
+      "",
+      "## Profile",
+      "",
+      "- [Home](\(Site.absoluteURL(for: Site.homePath))): English homepage and profile summary.",
+      "- [About](\(Site.absoluteURL(for: Site.aboutPath))): English about page.",
+      "- [Portuguese home](\(Site.absoluteURL(for: Site.localizedHomePath(for: Site.portugueseLocale)))): Portuguese homepage and profile summary.",
+      "- [All notes](\(Site.absoluteURL(for: Site.notesPath))): Human-readable note index.",
+      "- [Full AI context](\(Site.absoluteURL(for: "/llms-full.txt"))): Aggregated Markdown context for this site.",
+      "",
+      renderNoteList(title: "Notes in English", notes: englishNotes),
+      "",
+      renderNoteList(title: "Notas em Português", notes: portugueseNotes),
+    ].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
+  }
+
+  static func renderFull(context: PageRenderingContext) throws -> String {
+    let notes = sortedNotes(from: context.allItems)
+    let englishNotes = notes.filter { Site.currentLocale($0.locale) == Site.defaultLocale }
+    let portugueseNotes = notes.filter { Site.currentLocale($0.locale) == Site.portugueseLocale }
+
+    return [
+      "# \(Site.name)",
+      "",
+      "> \(Site.copy(for: Site.defaultLocale).intro)",
+      "",
+      "## Profile",
+      "",
+      "### English",
+      "",
+      Site.copy(for: Site.defaultLocale).intro,
+      "",
+      "- Home: \(Site.absoluteURL(for: Site.homePath))",
+      "- Notes: \(Site.absoluteURL(for: Site.notesPath))",
+      "- About: \(Site.absoluteURL(for: Site.aboutPath))",
+      "",
+      "### Portuguese",
+      "",
+      Site.copy(for: Site.portugueseLocale).intro,
+      "",
+      "- Home: \(Site.absoluteURL(for: Site.localizedHomePath(for: Site.portugueseLocale)))",
+      "- Notes: \(Site.absoluteURL(for: Site.localizedNotesPath(for: Site.portugueseLocale)))",
+      "- About: \(Site.absoluteURL(for: Site.localizedAboutPath(for: Site.portugueseLocale)))",
+      "",
+      try renderFullNotes(title: "Notes in English", notes: englishNotes),
+      "",
+      try renderFullNotes(title: "Notas em Português", notes: portugueseNotes),
+    ].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
+  }
+
+  static func writeMarkdownNotes(_ saga: Saga) throws {
+    for note in sortedNotes(from: saga.allItems) {
+      let outputURL = URL(fileURLWithPath: saga.outputPath.string)
+        .appendingPathComponent(outputRelativePath(for: markdownPath(for: note)))
+      try FileManager.default.createDirectory(
+        at: outputURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true
+      )
+      try cleanMarkdown(for: note).write(to: outputURL, atomically: true, encoding: .utf8)
+    }
+  }
+
+  static func markdownPath(for note: Item<NoteMetadata>) -> String {
+    let canonicalPath = canonicalPath(for: note)
+    let trimmedPath = canonicalPath.hasSuffix("/") ? String(canonicalPath.dropLast()) : canonicalPath
+    return "\(trimmedPath).md"
+  }
+
+  static func cleanMarkdown(for note: Item<NoteMetadata>) throws -> String {
+    let locale = Site.currentLocale(note.locale)
+    let canonicalPath = canonicalPath(for: note)
+    let noteMarkdownPath = markdownPath(for: note)
+    let body = try sourceBodyWithoutFrontMatterOrTitle(for: note)
+    let summary = note.metadata.summary ?? note.title
+    let tags = note.metadata.tags.isEmpty ? "none" : note.metadata.tags.joined(separator: ", ")
+
+    return [
+      "# \(note.title)",
+      "",
+      "> \(summary)",
+      "",
+      "- Language: \(locale)",
+      "- Canonical URL: \(Site.absoluteURL(for: canonicalPath))",
+      "- Markdown URL: \(Site.absoluteURL(for: noteMarkdownPath))",
+      "- Published: \(isoDate(note.date))",
+      "- Type: \(note.metadata.displayType.label(locale: locale))",
+      "- Tags: \(tags)",
+      "",
+      "---",
+      "",
+      body,
+    ].joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
+  }
+
+  private static func sortedNotes(from items: [AnyItem]) -> [Item<NoteMetadata>] {
+    items
+      .compactMap { $0 as? Item<NoteMetadata> }
+      .sorted { lhs, rhs in
+        if lhs.date != rhs.date {
+          return lhs.date > rhs.date
+        }
+
+        let lhsLocale = Site.currentLocale(lhs.locale)
+        let rhsLocale = Site.currentLocale(rhs.locale)
+        if lhsLocale != rhsLocale {
+          return lhsLocale < rhsLocale
+        }
+
+        return lhs.title < rhs.title
+      }
+  }
+
+  private static func renderNoteList(title: String, notes: [Item<NoteMetadata>]) -> String {
+    let lines = notes.map { note in
+      let summary = note.metadata.summary ?? note.title
+      return "- [\(note.title)](\(Site.absoluteURL(for: markdownPath(for: note)))): \(summary)"
+    }
+
+    return (["## \(title)", ""] + lines).joined(separator: "\n")
+  }
+
+  private static func renderFullNotes(title: String, notes: [Item<NoteMetadata>]) throws -> String {
+    let sections = try notes.map { try cleanMarkdown(for: $0) }
+    return (["## \(title)", ""] + sections).joined(separator: "\n")
+  }
+
+  private static func canonicalPath(for note: Item<NoteMetadata>) -> String {
+    note.url
+  }
+
+  private static func sourceBodyWithoutFrontMatterOrTitle(for note: Item<NoteMetadata>) throws -> String {
+    let source = try note.absoluteSource.read(.utf8)
+    let withoutFrontMatter = stripFrontMatter(from: source)
+    return stripLeadingTitle(from: withoutFrontMatter).trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private static func stripFrontMatter(from source: String) -> String {
+    let normalized = source.replacingOccurrences(of: "\r\n", with: "\n")
+    let lines = normalized.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+    guard lines.first == "---" else {
+      return normalized
+    }
+
+    guard let closingIndex = lines.dropFirst().firstIndex(of: "---") else {
+      return normalized
+    }
+
+    return lines.dropFirst(closingIndex + 1).joined(separator: "\n")
+  }
+
+  private static func stripLeadingTitle(from source: String) -> String {
+    var lines = source.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+
+    while lines.first?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == true {
+      lines.removeFirst()
+    }
+
+    if lines.first?.hasPrefix("# ") == true {
+      lines.removeFirst()
+    }
+
+    return lines.joined(separator: "\n")
+  }
+
+  private static func outputRelativePath(for path: String) -> String {
+    path.hasPrefix("/") ? String(path.dropFirst()) : path
+  }
+
+  private static func isoDate(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.calendar = Calendar(identifier: .gregorian)
+    formatter.locale = Locale(identifier: "en_US_POSIX")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
+    formatter.dateFormat = "yyyy-MM-dd"
+    return formatter.string(from: date)
+  }
+}

--- a/Sources/Rychillie/Core/Site.swift
+++ b/Sources/Rychillie/Core/Site.swift
@@ -85,6 +85,9 @@ struct SiteCopy {
   let notesDescription: String
   let noNotes: String
   let aboutTitle: String
+  let copyLinkAction: String
+  let copyMarkdownAction: String
+  let copiedAction: String
   let articleLabel: String
   let talkLabel: String
   let videoLabel: String
@@ -118,6 +121,9 @@ struct SiteCopy {
     notesDescription: "Writing, talks, experiments, and technical notes.",
     noNotes: "No notes published yet.",
     aboutTitle: "About",
+    copyLinkAction: "Copy Link",
+    copyMarkdownAction: "Markdown",
+    copiedAction: "Copied",
     articleLabel: "Article",
     talkLabel: "Talk",
     videoLabel: "Video",
@@ -143,6 +149,9 @@ struct SiteCopy {
     notesDescription: "Textos, talks, experimentos e notas técnicas.",
     noNotes: "Nenhuma nota publicada ainda.",
     aboutTitle: "Sobre",
+    copyLinkAction: "Copiar link",
+    copyMarkdownAction: "Markdown",
+    copiedAction: "Copiado",
     articleLabel: "Artigo",
     talkLabel: "Talk",
     videoLabel: "Vídeo",

--- a/Sources/Rychillie/Layout/Layout.swift
+++ b/Sources/Rychillie/Layout/Layout.swift
@@ -20,6 +20,7 @@ func baseHtml(
   locale: String,
   translations: [String: String] = [:],
   ogType: String = "website",
+  markdownAlternatePath: String? = nil,
   preloadImages: [ImagePreload] = [],
   @NodeBuilder children: () -> NodeConvertible
 ) -> Node {
@@ -44,6 +45,9 @@ func baseHtml(
       }
       if let defaultAlternateURL {
         link(href: defaultAlternateURL, hreflang: "x-default", rel: "alternate")
+      }
+      if let markdownAlternatePath {
+        link(href: Site.absoluteURL(for: markdownAlternatePath), rel: "alternate", type: "text/markdown")
       }
       meta(content: documentTitle, customAttributes: ["property": "og:title"])
       meta(content: description, customAttributes: ["property": "og:description"])

--- a/Sources/Rychillie/Pages/Note.swift
+++ b/Sources/Rychillie/Pages/Note.swift
@@ -5,6 +5,8 @@ func renderNote(context: ItemRenderingContext<NoteMetadata>) -> Node {
   let locale = Site.currentLocale(context.locale)
   let copy = Site.copy(for: locale)
   let canonicalPath = context.translations[locale] ?? context.item.url
+  let canonicalURL = Site.absoluteURL(for: canonicalPath)
+  let markdownPath = LLMS.markdownPath(for: context.item)
   let description = context.item.metadata.summary ?? context.item.title
 
   return baseHtml(
@@ -13,24 +15,143 @@ func renderNote(context: ItemRenderingContext<NoteMetadata>) -> Node {
     canonicalPath: canonicalPath,
     locale: locale,
     translations: context.translations,
-    ogType: "article"
+    ogType: "article",
+    markdownAlternatePath: markdownPath
   ) {
     pageFrame(activeSection: .notes, locale: locale, translations: context.translations) {
       article(class: Theme.Notes.article) {
         header(class: Theme.Notes.articleHeader) {
-          a(class: Theme.Notes.backLink, href: Site.localizedNotesPath(for: locale)) { copy.notesNav }
           h1(class: Theme.Notes.pageTitle) { context.item.title }
-          div(class: Theme.Card.metaRow) {
-            p(class: Theme.Card.meta) { context.item.metadata.displayType.label(locale: locale) }
-            span(class: Theme.Card.metaDot) {}
-            p(class: Theme.Card.meta) { Site.displayDate(context.item.date, locale: locale) }
+          div(class: Theme.Notes.articleMeta) {
+            div(class: Theme.Notes.metaGroup) {
+              p(class: Theme.Card.meta) { context.item.metadata.displayType.label(locale: locale) }
+              span(class: Theme.Card.metaDot) {}
+              p(class: Theme.Card.meta) { Site.displayDate(context.item.date, locale: locale) }
+            }
+            noteCopyActions(copy: copy, canonicalURL: canonicalURL, markdownPath: markdownPath)
           }
-          tagList(context.item.metadata.tags)
         }
         div(class: Theme.Markdown.content) {
           Node.raw(context.item.body)
         }
       }
+      noteCopyScript()
     }
+  }
+}
+
+@NodeBuilder
+func noteCopyActions(copy: SiteCopy, canonicalURL: String, markdownPath: String) -> NodeConvertible {
+  div(class: Theme.Notes.actions) {
+    span(class: Theme.Notes.desktopMetaDot) {}
+    button(
+      class: Theme.Notes.actionButton,
+      type: "button",
+      customAttributes: [
+        "data-copy-note-link": "",
+        "data-copy-value": canonicalURL,
+        "data-default-label": copy.copyLinkAction,
+        "data-copied-label": copy.copiedAction,
+      ]
+    ) {
+      copy.copyLinkAction
+    }
+
+    span(class: Theme.Card.metaDot) {}
+    button(
+      class: Theme.Notes.actionButton,
+      type: "button",
+      customAttributes: [
+        "data-copy-note-markdown": "",
+        "data-markdown-url": markdownPath,
+        "data-default-label": copy.copyMarkdownAction,
+        "data-copied-label": copy.copiedAction,
+      ]
+    ) {
+      copy.copyMarkdownAction
+    }
+  }
+}
+
+func noteCopyScript() -> Node {
+  script {
+    Node.raw("""
+    (function () {
+      var timers = new WeakMap();
+
+      function markCopied(button) {
+        var copiedLabel = button.dataset.copiedLabel;
+        var defaultLabel = button.dataset.defaultLabel;
+        if (!copiedLabel || !defaultLabel) {
+          return;
+        }
+
+        button.textContent = copiedLabel;
+        if (timers.has(button)) {
+          window.clearTimeout(timers.get(button));
+        }
+
+        timers.set(button, window.setTimeout(function () {
+          button.textContent = defaultLabel;
+        }, 1600));
+      }
+
+      async function copyText(text) {
+        if (!navigator.clipboard || !window.isSecureContext) {
+          throw new Error("Clipboard unavailable");
+        }
+
+        await navigator.clipboard.writeText(text);
+      }
+
+      document.querySelectorAll("[data-copy-note-link]").forEach(function (button) {
+        button.addEventListener("click", async function () {
+          var value = button.dataset.copyValue;
+          if (!value) {
+            return;
+          }
+
+          try {
+            await copyText(value);
+            markCopied(button);
+          } catch (_) {
+            window.prompt(button.dataset.defaultLabel || "Copy link", value);
+          }
+        });
+      });
+
+      document.querySelectorAll("[data-copy-note-markdown]").forEach(function (button) {
+        button.addEventListener("click", async function () {
+          var markdownURL = button.dataset.markdownUrl;
+          if (!markdownURL) {
+            return;
+          }
+
+          try {
+            var response = await fetch(markdownURL, {
+              headers: {
+                "Accept": "text/markdown,text/plain;q=0.9,*/*;q=0.8"
+              }
+            });
+            if (!response.ok) {
+              throw new Error("Markdown unavailable");
+            }
+
+            var contentType = response.headers.get("content-type") || "";
+            var markdown = await response.text();
+            var start = markdown.trimStart().slice(0, 32).toLowerCase();
+            if (contentType.indexOf("text/html") !== -1 || start.indexOf("<!doctype") === 0 || start.indexOf("<html") === 0) {
+              throw new Error("Markdown response was HTML");
+            }
+
+            await copyText(markdown);
+            markCopied(button);
+          } catch (_) {
+            window.location.href = markdownURL;
+          }
+        });
+      });
+    })();
+    """)
   }
 }

--- a/Sources/Rychillie/Styles/Theme.swift
+++ b/Sources/Rychillie/Styles/Theme.swift
@@ -59,6 +59,11 @@ enum Theme {
     static let article = "w-full"
     static let articleHeader = "mb-6 flex w-full flex-col items-start gap-3"
     static let backLink = "text-sm font-semibold leading-5 text-[#9d2e29] no-underline hover:underline dark:text-[#e05e58]"
+    static let articleMeta = "flex w-full flex-wrap items-center gap-x-1 gap-y-2"
+    static let metaGroup = "flex min-w-0 items-center gap-1"
+    static let actions = "flex w-full items-center gap-1 md:w-auto"
+    static let desktopMetaDot = "hidden size-0.5 rounded-full bg-neutral-800 dark:bg-neutral-200 md:block"
+    static let actionButton = "m-0 appearance-none border-0 bg-transparent p-0 text-sm font-normal leading-5 text-[#9d2e29] underline decoration-neutral-400 underline-offset-2 transition-colors hover:decoration-[#9d2e29] dark:text-[#e05e58] dark:decoration-neutral-600 dark:hover:decoration-[#e05e58]"
     static let tags = "m-0 flex list-none flex-wrap gap-2 p-0"
     static let tag = "rounded border border-neutral-200 bg-neutral-50 px-2.5 py-0.5 text-sm leading-5 text-neutral-800 dark:border-neutral-800 dark:bg-neutral-950 dark:text-neutral-200"
   }

--- a/Sources/Rychillie/main.swift
+++ b/Sources/Rychillie/main.swift
@@ -48,6 +48,7 @@ try await Saga(input: "content", output: "deploy")
   }
   .afterWrite { saga in
     try removeTailwindSourceFromDeploy(saga)
+    try LLMS.writeMarkdownNotes(saga)
     try generateHomeImages(saga)
   }
   .postProcess { content, relativePath in
@@ -73,6 +74,8 @@ try await Saga(input: "content", output: "deploy")
   .createPage("about/index.html", forEachLocale: swim(renderAbout))
   .createPage("articles/index.html", using: Saga.redirectHTML(to: Site.notesPath))
   .createPage("articles/hello-world/index.html", using: Saga.redirectHTML(to: "\(Site.notesPath)hello-world/"))
+  .createPage("llms.txt", using: LLMS.renderIndex)
+  .createPage("llms-full.txt", using: LLMS.renderFull)
   .createPage(
     "sitemap.xml",
     using: Saga.sitemap(baseURL: Site.baseURL) { path in

--- a/content/_headers
+++ b/content/_headers
@@ -14,6 +14,18 @@
   Content-Type: text/plain; charset=utf-8
   Cache-Control: public, max-age=3600
 
+/llms.txt
+  Content-Type: text/plain; charset=utf-8
+
+/llms-full.txt
+  Content-Type: text/plain; charset=utf-8
+
+/notes/*.md
+  Content-Type: text/markdown; charset=utf-8
+
+/pt-BR/notes/*.md
+  Content-Type: text/markdown; charset=utf-8
+
 /sitemap.xml
   Content-Type: application/xml; charset=utf-8
   Cache-Control: public, max-age=3600


### PR DESCRIPTION
Adds `/llms.txt`, `/llms-full.txt`, and clean per-note `.md` output for agents, with UTF-8 Cloudflare headers and Markdown alternates in note pages.

Updates note headers to remove the back link/tag pills and move copy actions into compact inline metadata links with same-origin Markdown fetching.

The copy script rejects accidental HTML responses and preserves canonical production URLs inside generated Markdown.

Validation: `saga build`, local `saga dev` preview/curl checks, `git diff --check`, and whitespace checks.