### PR TITLE
Update docs for current site implementation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,17 +11,30 @@ Keep agent-facing instructions and repository documentation in English.
 - Content lives in `content/`.
 - Generated output goes to `deploy/` and should not be edited or committed.
 - Generated Tailwind output goes to `content/static/styles.css` and should not be edited or committed.
+- Generated responsive image variants go to `deploy/static/images/` and should not be edited or committed.
 - `content/static/tailwind.css` is the Tailwind source file. It currently imports Tailwind CSS.
-- `Sources/Rychillie/theme.swift` centralizes Tailwind utility class strings for layout, typography, dark mode, article lists, tags, and Markdown rendering.
-- `Sources/Rychillie/main.swift` is responsible for compiling Tailwind through `SwiftTailwind`, running Saga from `content/` to `deploy/`, registering Markdown readers/writers, and removing `static/tailwind.css` from the generated output.
+- `Sources/Rychillie/Styles/Theme.swift` centralizes Tailwind utility class strings for layout, typography, dark mode, cards, notes, tags, and Markdown rendering.
+- `Sources/Rychillie/Core/` contains site constants, localized copy, content metadata, Markdown/LLMS generation, and processors.
+- `Sources/Rychillie/Layout/` contains the shared HTML shell, reusable layout components, and inline Swift-rendered SVG icons.
+- `Sources/Rychillie/Pages/` contains the home, notes index, note detail, and about renderers.
+- `Sources/Rychillie/main.swift` is responsible for compiling Tailwind through `SwiftTailwind`, running Saga from `content/` to `deploy/`, registering Markdown readers/writers, rendering localized pages, generating LLMS/Markdown outputs, generating responsive images, and removing source-only static files from generated output.
 
 ## Development Rules
 
 - Prefer editing source templates, content files, and styles over generated files.
 - Prefer adding or changing reusable visual classes in `Theme` instead of scattering long class strings through templates, unless a class is truly one-off.
-- If styling changes require new Tailwind utilities, update the Swift templates/theme or `content/static/tailwind.css`; do not edit `content/static/styles.css`.
-- Pages and articles are Markdown files under `content/`. Article metadata uses `tags` and optional `summary`.
-- `Sources/Rychillie/templates.swift` renders pages, article pages, article indexes, tag pages, the shared shell, hashed CSS link, and Moon syntax highlighting.
+- If styling changes require new Tailwind utilities, update Swift templates, `Theme`, or `content/static/tailwind.css`; do not edit `content/static/styles.css`.
+- Pages and notes are Markdown files under `content/`, localized under `content/en/notes/` and `content/pt-BR/notes/`.
+- Note metadata uses required `tags`, optional `summary`, and optional `type`. Supported note types are `article`, `talk`, `video`, `participated`, and `other`; missing `type` defaults to `article`.
+- The home page bento grid links to localized event notes and should keep English and Portuguese paths in sync.
+- Use `Sources/Rychillie/Core/Site.swift` for shared site constants, localized copy, locale paths, and external links.
+- Use `Sources/Rychillie/Layout/Layout.swift` for the base shell, metadata, canonical/alternate links, Markdown alternates, hashed CSS link, navigation, and footer.
+- Use `Sources/Rychillie/Layout/Components.swift` for shared cards, responsive image helpers, note cards, and inline action links.
+- Use `Sources/Rychillie/Layout/Icons.swift` for inline SVG icons instead of adding static icon files.
+- Use `Sources/Rychillie/Core/LLMS.swift` for `/llms.txt`, `/llms-full.txt`, and clean per-note `.md` output. Do not hand-edit generated Markdown in `deploy/`.
+- Use `Sources/Rychillie/Core/Processors.swift` for Moon syntax highlighting processors.
+- `content/static/images/` contains source images. `Sources/Scripts/generate-images.sh` creates optimized PNG/WebP/GIF variants during `saga build`.
+- `content/_headers` controls Cloudflare Pages cache headers and content types for generated CSS, images, Markdown, text, and XML files.
 - Use `origin/main` as the comparison base for diffs and pull requests in Conductor workspaces.
 - Do not rename the current branch unless the user explicitly asks.
 - Keep changes focused on the requested website behavior, content, or configuration.
@@ -29,15 +42,17 @@ Keep agent-facing instructions and repository documentation in English.
 
 ## Deployment
 
+- Pull request CI runs from `.github/workflows/ci.yml`.
 - GitHub Actions deploys to Cloudflare Pages on pushes to `main`.
 - The workflow lives in `.github/workflows/deploy-cloudflare-pages.yml`.
-- The workflow uses `macos-latest`, installs the Saga CLI, runs `saga build`, verifies `deploy/index.html`, and deploys `deploy/` with `cloudflare/wrangler-action@v3`.
+- CI and deploy workflows use `macos-latest`, install the Saga CLI, ImageMagick, and SwiftLint, run `swiftlint lint --quiet`, run `saga build`, and verify `deploy/index.html`.
+- The deploy workflow deploys `deploy/` with `cloudflare/wrangler-action@v3`.
 - The Cloudflare Pages project name is `rychillie`.
 
 ## Conductor
 
-- This repository includes shared Conductor scripts in `conductor.json`.
-- Setup runs `zsh Sources/Scripts/conductor-setup.sh` and verifies Swift and the Saga CLI.
+- This repository currently uses the legacy shared Conductor configuration in `conductor.json`; do not migrate it to `.conductor/settings.toml` unless the user explicitly asks.
+- Setup runs `zsh Sources/Scripts/conductor-setup.sh` and verifies Swift, the Saga CLI, ImageMagick, and SwiftLint.
 - Run starts `saga dev` through `zsh Sources/Scripts/conductor-run.sh`.
 - The run script uses `CONDUCTOR_PORT`, falling back to `3000` outside Conductor.
 - `runScriptMode` is `concurrent` because each workspace receives its own port range.
@@ -45,10 +60,11 @@ Keep agent-facing instructions and repository documentation in English.
 ## Validation
 
 - Run `saga build` after meaningful changes to Swift templates, Saga configuration, Tailwind styling, or content.
+- Run `swiftlint lint --quiet` after meaningful Swift changes.
 - For documentation-only changes, `git diff --check` is sufficient unless the docs describe behavior that needs verification.
 - Use `saga dev --port "$CONDUCTOR_PORT"` for local preview inside Conductor when needed.
-- If the Saga CLI is missing, install it with:
+- If required build tools are missing, install them with:
 
 ```sh
-brew install loopwerk/tap/saga
+brew install loopwerk/tap/saga imagemagick swiftlint
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,17 @@
 
 Personal static website built with [Saga](https://getsaga.dev), a Swift static site generator.
 
-The site is generated from localized Markdown content in `content/`, rendered by Swift templates, styled with Tailwind CSS utilities, and deployed to Cloudflare Pages.
+The site is generated from localized Markdown content in `content/`, rendered by Swift templates, styled with Tailwind CSS utilities, optimized during the Saga build, and deployed to Cloudflare Pages.
+
+Current build features include:
+
+- English and Brazilian Portuguese content with Saga i18n.
+- Tailwind CSS compiled through [`SwiftTailwind`](https://github.com/loopwerk/SwiftTailwind).
+- Moon-powered syntax highlighting for Markdown code blocks.
+- SEO metadata, canonical URLs, alternate locale links, `robots.txt`, and `sitemap.xml`.
+- Cloudflare Pages cache and content-type headers from `content/_headers`.
+- Responsive image variants generated with ImageMagick.
+- AI-friendly `/llms.txt`, `/llms-full.txt`, and clean per-note Markdown output.
 
 ## Requirements
 
@@ -40,7 +50,7 @@ swiftlint lint --quiet
 
 Saga reads localized content from `content/` and writes the generated site to `deploy/`.
 
-The generated files in `deploy/` are ignored by git. Tailwind also writes `content/static/styles.css`, which is generated and ignored.
+The generated files in `deploy/` are ignored by git. Tailwind also writes `content/static/styles.css`, which is generated and ignored. Responsive image variants are generated into `deploy/static/images/` during the build and are not committed.
 
 ## Styling
 
@@ -54,6 +64,21 @@ Tailwind CSS is compiled during the Saga build through [`SwiftTailwind`](https:/
 
 When changing visual styling, prefer updating `Theme` or `content/static/tailwind.css`. Do not edit `content/static/styles.css` directly.
 
+## Content
+
+Content is localized by folder:
+
+- `content/en/notes/`: English notes. These build at `/notes/...`.
+- `content/pt-BR/notes/`: Brazilian Portuguese notes. These build at `/pt-BR/notes/...`.
+
+Note front matter uses:
+
+- `tags`: required note tags.
+- `summary`: optional short summary used by note cards, SEO metadata, and generated Markdown.
+- `type`: optional note type. Supported values are `article`, `talk`, `video`, `participated`, and `other`; missing values default to `article`.
+
+The current home page uses localized bento image links that point to event notes, including the `participated` notes for BrazilJS Conf 2024, Build in Public Meetup 2026, and ClawCon Belo Horizonte 2026.
+
 ## Site Generation
 
 The main Saga pipeline lives in `Sources/Rychillie/main.swift`.
@@ -63,32 +88,65 @@ The main Saga pipeline lives in `Sources/Rychillie/main.swift`.
 - It configures Saga i18n with `en` as the default locale and `pt-BR` under `/pt-BR/`.
 - It recompiles Tailwind when CSS changes during development.
 - It ignores generated `styles.css` changes in the Saga file watcher.
-- It registers note Markdown files from `content/en/notes/` and `content/pt-BR/notes/` with `NoteMetadata`, including required `tags` and optional `summary`.
+- It registers note Markdown files from `content/en/notes/` and `content/pt-BR/notes/` with `NoteMetadata`.
 - It renders template-driven home, notes, and about pages once per locale.
+- It redirects legacy `/articles/` to `/notes/`.
+- It writes `/llms.txt`, `/llms-full.txt`, and per-note `.md` files for agent-readable Markdown access.
+- It writes `sitemap.xml`.
+- It injects a missing HTML doctype during post-processing.
+- It removes `static/tailwind.css` and static icon files from generated output.
+- It generates responsive PNG/WebP image variants and the optimized wave animation into `deploy/static/images/`.
 
 Templates are built with Saga Swim renderer helpers and use [Moon](https://github.com/loopwerk/Moon) for code highlighting.
+
+## Assets
+
+- `content/static/images/`: Source images committed to the repository.
+- `Sources/Scripts/generate-images.sh`: ImageMagick script used by the Saga build to create responsive output variants in `deploy/static/images/`.
+- `Sources/Rychillie/Layout/Icons.swift`: Inline Swift-rendered SVG icons used by the templates.
+- `content/favicon.ico`: Site favicon.
+- `content/_headers`: Cloudflare Pages headers for cache behavior and generated text/Markdown/XML content types.
+
+Do not commit generated image variants from `deploy/static/images/`.
 
 ## Project Layout
 
 - `Package.swift`: Swift package definition and Saga dependencies.
 - `Sources/Rychillie/main.swift`: Saga pipeline, Tailwind compilation, content registration, and output cleanup.
+- `Sources/Rychillie/Core/`: Site constants, localized copy, note metadata, Markdown/LLMS generation, and processors.
 - `Sources/Rychillie/Layout/`: Shared HTML shell and reusable layout components.
+- `Sources/Rychillie/Layout/Icons.swift`: Inline SVG icon rendering.
 - `Sources/Rychillie/Pages/`: Home, notes, note detail, and about renderers.
 - `Sources/Rychillie/Styles/Theme.swift`: Tailwind utility class constants used by the templates.
 - `Sources/Scripts/`: Repository scripts used by Conductor.
 - `content/en/notes/`: Default English notes. These build at `/notes/...`.
 - `content/pt-BR/notes/`: Brazilian Portuguese notes. These build at `/pt-BR/notes/...`.
 - `content/static/`: Locale-independent static assets.
+- `content/static/images/`: Source images for home, social cards, brand cards, and animation.
 - `content/static/tailwind.css`: Tailwind source CSS.
 - `content/static/styles.css`: Generated Tailwind CSS output. This file is not committed.
+- `content/_headers`: Cloudflare Pages headers.
+- `content/robots.txt`: Robots file pointing to the generated sitemap.
 - `deploy/`: Generated static site output. This directory is not committed.
+- `.github/workflows/ci.yml`: Pull request and manual CI workflow.
 - `.github/workflows/deploy-cloudflare-pages.yml`: GitHub Actions workflow for Cloudflare Pages deploys.
 
-## Deployment
+## CI and Deployment
+
+Pull request CI runs from `.github/workflows/ci.yml`.
+
+The CI workflow:
+
+1. Runs on `macos-latest`.
+2. Checks out the repository.
+3. Installs the Saga CLI, ImageMagick, and SwiftLint with Homebrew.
+4. Runs `swiftlint lint --quiet`.
+5. Runs `saga build`.
+6. Verifies `deploy/index.html`.
 
 GitHub Actions deploys the site to Cloudflare Pages whenever code is pushed to `main`.
 
-The workflow:
+The deploy workflow:
 
 1. Runs on `macos-latest`.
 2. Checks out the repository.
@@ -100,9 +158,10 @@ The workflow:
 
 ## Conductor
 
-This repository includes shared Conductor scripts in `conductor.json`.
+This repository currently uses the legacy shared Conductor configuration in `conductor.json`.
 
 - Setup verifies that Swift, the Saga CLI, ImageMagick, and SwiftLint are available.
 - Run starts `saga dev` on `CONDUCTOR_PORT`, falling back to port `3000` outside Conductor.
+- The setup and run commands delegate to scripts in `Sources/Scripts/`.
 
 Conductor scripts are configured to run concurrently because each workspace receives its own port range.


### PR DESCRIPTION
## Summary
- Updates README to document the current Swift/Saga architecture, localized notes, image generation, LLMS Markdown outputs, and CI/deploy workflow.
- Refreshes AGENTS guidance with the current source layout, note metadata, generated asset rules, and legacy Conductor configuration.

## Validation
- git diff --check